### PR TITLE
Add PageSpeed.ONE to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - [SEMrush](https://www.semrush.com/) - Provides keyword research, competitor analysis, and site auditing tools.
 - [Moz Pro](https://moz.com/products/pro) - Offers a suite of SEO tools, including keyword research, link analysis, and site auditing.
 - [Screaming Frog SEO Spider](https://www.screamingfrog.co.uk/seo-spider/) - A powerful website crawler that helps with technical SEO audits.
+- [PageSpeed.ONE](https://pagespeed.one/en) - Monitors page speed and Core Web Vitals with daily automated tests, CrUX field data, and alerts when scores drop.
 
 ## Guides and Tutorials
 - [Google's Search Engine Optimization (SEO) Starter Guide](https://support.google.com/webmasters/answer/7451184) - A comprehensive guide by Google on the basics of SEO.


### PR DESCRIPTION
### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows our quality and content standards.
- [ ] I have not added a link to my own project if it's not notable or widely used. (See disclosure below.)

### Description of the Change

Adds PageSpeed.ONE to the bottom of the **Tools** section:

- [PageSpeed.ONE](https://pagespeed.one/en) - Monitors page speed and Core Web Vitals with daily automated tests, CrUX field data, and alerts when scores drop.

### Additional Notes (if any)

Disclosure: I'm a developer of PageSpeed.ONE, so please treat this as a suggestion rather than a neutral nomination. Happy to adjust the wording or placement, or drop it, if it doesn't meet the bar for this list.
