### PR TITLE
Add SeoMods to Tools (reCAPTCHA issue from #21 fixed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - [SEMrush](https://www.semrush.com/) - Provides keyword research, competitor analysis, and site auditing tools.
 - [Moz Pro](https://moz.com/products/pro) - Offers a suite of SEO tools, including keyword research, link analysis, and site auditing.
 - [Screaming Frog SEO Spider](https://www.screamingfrog.co.uk/seo-spider/) - A powerful website crawler that helps with technical SEO audits.
+- [SeoMods](https://seomods.com) - A free suite of 80+ SEO tools covering on-page and technical audits, keyword research, backlink analysis, and WHOIS/DNS/SSL lookups. No signup or usage limits.
 
 ## Guides and Tutorials
 - [Google's Search Engine Optimization (SEO) Starter Guide](https://support.google.com/webmasters/answer/7451184) - A comprehensive guide by Google on the basics of SEO.


### PR DESCRIPTION
Hi @brandonhimpfen — opening this as a fresh PR because #21 is closed and comments there don't reach you.

You closed #21 with the `site-doesnt-work` label, and you were right: a misconfigured reCAPTCHA check was blocking tool runs, so the tools genuinely appeared broken. That's fixed — every tool now runs with no signup and no CAPTCHA wall. Easy to verify on any tool page, for example:

- https://seomods.com/tools/backlink-checker
- https://seomods.com/tools/meta-tag-analyzer

SeoMods is a free suite of 80+ SEO tools: on-page and technical audits, Core Web Vitals, keyword and backlink research, a site explorer, schema generators, and WHOIS/DNS/SSL lookups. Live data, no account, no usage limits.

Line added, matching the existing format:

- [SeoMods](https://seomods.com) - A free suite of 80+ SEO tools covering on-page and technical audits, keyword research, backlink analysis, and WHOIS/DNS/SSL lookups. No signup or usage limits.

Thanks for the original review — it caught a real bug on our side.
